### PR TITLE
Fix temperature color in i3blocks

### DIFF
--- a/.config/i3/i3blocks/scripts/temperature
+++ b/.config/i3/i3blocks/scripts/temperature
@@ -23,4 +23,4 @@ print(icon + ' ' + temperature_str + '°C')
 print(icon + ' ' + temperature_str + '°C')
 
 if temperature > 75:
-	print('ff3300')
+	print('#ff3300')


### PR DESCRIPTION
Add missing hash symbol before color hex code.